### PR TITLE
Shadowed SignAnnouncement {ChannelUpdate, NodeAnnouncement}.

### DIFF
--- a/remotesigner/ecdh.go
+++ b/remotesigner/ecdh.go
@@ -46,3 +46,7 @@ func (rs *RemoteSignerECDH) ECDH(pubKey *btcec.PublicKey) ([32]byte, error) {
 
 	return secretLocal, nil
 }
+
+// A compile time check to ensure that RemoteSignerECDH implements the
+// PubKeyECDH interface.
+var _ keychain.SingleKeyECDH = (*RemoteSignerECDH)(nil)


### PR DESCRIPTION
ChannelAnnouncement not encountered by integration tests.

Not sure why we don't encounter ChannelAnnouncement.  We need more strategy/tactics for dealing with the two-pass
ChannelAnnouncement signing anyway.
